### PR TITLE
Implements WKUIDelegate for iOS

### DIFF
--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -16,7 +16,11 @@ export function pageLoaded(args: observable.EventData) {
         console.log('finished');
         console.log(args.url);
     });
-    // webView.src = 'https://www.google.com';
+
+    webView.on('open', data => {
+        console.log(data.eventName);
+        console.log(JSON.stringify(data.object.body));
+    });
 }
 
 

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -1,5 +1,5 @@
-<Page title="WebKit WebView" 
-  xmlns="http://schemas.nativescript.org/tns.xsd" loaded="pageLoaded" class="page" 
+<Page title="WebKit WebView"
+  xmlns="http://schemas.nativescript.org/tns.xsd" loaded="pageLoaded" class="page"
   xmlns:ui="nativescript-webkit-webview">
   <StackLayout class="p-20">
     <Button class="btn btn-primary" row="0" text="Reload" tap="reload"></Button>

--- a/demo/app/www/index.html
+++ b/demo/app/www/index.html
@@ -48,11 +48,16 @@
                 ports[e.data] = e.ports[0];
             }
         }
+
+        openWindow = function() {
+            window.open('http://www.google.com');
+        }
     </script>
 </head>
 
 <body onload="initiate();">
     <p>Webkit WebViewloaded!</p>
+    <button onclick="openWindow()">CLICK ME</button>
 </body>
 
 </html>

--- a/src/webkit-webview.ios.ts
+++ b/src/webkit-webview.ios.ts
@@ -54,7 +54,6 @@ class WKNavigationDelegateImpl extends NSObject
     const owner = this._owner.get();
     if (owner && navigationAction.request.URL) {
       let navType: NavigationType = 'other';
-
       switch (navigationAction.navigationType) {
         case WKNavigationType.LinkActivated:
           navType = 'linkClicked';
@@ -70,6 +69,9 @@ class WKNavigationDelegateImpl extends NSObject
           break;
         case WKNavigationType.FormResubmitted:
           navType = 'formResubmitted';
+          break;
+        case WKNavigationType.Other:
+          navType = 'other';
           break;
       }
       decisionHandler(WKNavigationActionPolicy.Allow);
@@ -115,12 +117,99 @@ class WKScriptMessageHandlerImpl extends NSObject
   }
 }
 
+class WKUIDelegateImpl extends NSObject implements WKUIDelegate {
+
+  static ObjCProtocols = [WKUIDelegate];
+
+  static initWithOwner(owner: WeakRef<TNSWKWebView>): WKUIDelegateImpl {
+    const handler = <WKUIDelegateImpl>WKUIDelegateImpl.new();
+    handler._owner = owner;
+    return handler;
+  }
+
+  private _owner: WeakRef<TNSWKWebView>;
+
+  webViewCommitPreviewingViewController?(webView: WKWebView, previewingViewController: UIViewController) {
+    // TODO called when the user performs a pop action on the preview
+  }
+
+  webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures?(webView: WKWebView, configuration: WKWebViewConfiguration, navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures): WKWebView {
+    const owner = this._owner.get();
+    if (owner) {
+      let eventName;
+      switch (navigationAction.navigationType) {
+        case WKNavigationType.LinkActivated:
+          eventName = 'linkClicked';
+          break;
+        case WKNavigationType.FormSubmitted:
+          eventName = 'formSubmitted';
+          break;
+        case WKNavigationType.BackForward:
+          eventName = 'backForward';
+          break;
+        case WKNavigationType.Reload:
+          eventName = 'reload';
+          break;
+        case WKNavigationType.FormResubmitted:
+          eventName = 'formResubmitted';
+          break;
+        case WKNavigationType.Other:
+          eventName = 'other';
+          break;
+      }
+      owner.notify({
+        eventName: TNSWKWebView.openEvent,
+        object: fromObject({
+          name: eventName,
+          body: {
+            url: navigationAction.request.URL.absoluteString
+          }
+        })
+      });
+    }
+    return owner.ios;
+  }
+
+  webViewDidClose?(webView: WKWebView) {
+    const owner = this._owner.get();
+    owner.notify({
+      eventName: TNSWKWebView.closedEvent,
+      object: fromObject({})
+    });
+  }
+
+  webViewPreviewingViewControllerForElementDefaultActions?(webView: WKWebView, elementInfo: WKPreviewElementInfo, previewActions: NSArray<WKPreviewActionItem>): UIViewController {
+    // TODO called when the user performs a peek action
+    return null;
+  }
+
+  webViewRunJavaScriptAlertPanelWithMessageInitiatedByFrameCompletionHandler?(webView: WKWebView, message: string, frame: WKFrameInfo, completionHandler: () => void) {
+    // TODO displaying UI JavaScript alert panels
+  }
+
+  webViewRunJavaScriptConfirmPanelWithMessageInitiatedByFrameCompletionHandler?(webView: WKWebView, message: string, frame: WKFrameInfo, completionHandler: (p1: boolean) => void) {
+    // TODO displaying UI JavaScript confirm panels
+  }
+
+  webViewRunJavaScriptTextInputPanelWithPromptDefaultTextInitiatedByFrameCompletionHandler?(webView: WKWebView, prompt: string, defaultText: string, frame: WKFrameInfo, completionHandler: (p1: string) => void) {
+    // TODO displaying UI JavaScript prompt panels
+  }
+
+  webViewShouldPreviewElement?(webView: WKWebView, elementInfo: WKPreviewElementInfo): boolean {
+    // TODO - Responding to Force Touch Actions
+    return false;
+  }
+
+}
+
 const srcProperty = new Property<TNSWKWebView, string>({ name: 'src' });
 
 export class TNSWKWebView extends View {
   public static messageHandlerEvent = 'message';
   public static loadStartedEvent = 'loadStarted';
   public static loadFinishedEvent = 'loadFinished';
+  public static closedEvent = 'closed';
+  public static openEvent = 'open';
 
   public src: string;
   private _ios: WKWebView;
@@ -128,6 +217,8 @@ export class TNSWKWebView extends View {
   private _scriptMessageHandler: WKScriptMessageHandlerImpl;
   private _userContentController: WKUserContentController;
   private _delegate: WKNavigationDelegateImpl;
+  private _uiDelegate: WKUIDelegateImpl;
+
   constructor() {
     super();
     const jScript =
@@ -144,6 +235,7 @@ export class TNSWKWebView extends View {
     this._userContentController.addUserScript(wkUScript);
     const config = WKWebViewConfiguration.new();
     this._delegate = WKNavigationDelegateImpl.initWithOwner(new WeakRef(this));
+    this._uiDelegate = WKUIDelegateImpl.initWithOwner(new WeakRef(this));
     config.preferences.setValueForKey(true, 'allowFileAccessFromFileURLs');
     this.nativeView = this._ios = new WKWebView({
       frame: CGRectZero,
@@ -210,10 +302,12 @@ export class TNSWKWebView extends View {
     super.onLoaded();
     this._ios.configuration.userContentController = this._userContentController;
     this._ios.navigationDelegate = this._delegate;
+    this._ios.UIDelegate = this._uiDelegate;
   }
 
   onUnloaded(): void {
     this._ios.navigationDelegate = null;
+    this._ios.UIDelegate = null;
     super.onUnloaded();
   }
 


### PR DESCRIPTION
Used for hooking onto `window.open` requests inside the frame or if a window source successfully closes.

Future hooks are marked with TODO (i.e. Force touch integrations for preview window).