### PR TITLE
Fixes device read-permission access on file directories

### DIFF
--- a/src/webkit-webview.ios.ts
+++ b/src/webkit-webview.ios.ts
@@ -357,10 +357,11 @@ export class TNSWKWebView extends View {
         : myUrl;
       this._ios.loadFileURLAllowingReadAccessToURL(myUrl, myReadAccessUrl);
     } else if (url.startsWith('file:///')) {
-      const myUrl = NSURL.URLWithString(encodeURI('file://' + url));
-      const myReadAccessUrl = readAccessUrl
-        ? NSURL.fileURLWithPath(readAccessUrl)
-        : myUrl;
+      if (url.indexOf('/') !== -1) {
+        url = url.substring(0, url.lastIndexOf('/'));
+      }
+      const myUrl = NSURL.URLWithString(encodeURI(url));
+      const myReadAccessUrl = NSURL.fileURLWithPath(url);
       this._ios.loadFileURLAllowingReadAccessToURL(myUrl, myReadAccessUrl);
     } else {
       const reTilda = new RegExp('^~/');

--- a/src/webkit-webview.ios.ts
+++ b/src/webkit-webview.ios.ts
@@ -357,11 +357,12 @@ export class TNSWKWebView extends View {
         : myUrl;
       this._ios.loadFileURLAllowingReadAccessToURL(myUrl, myReadAccessUrl);
     } else if (url.startsWith('file:///')) {
+      let directory = url;
       if (url.indexOf('/') !== -1) {
-        url = url.substring(0, url.lastIndexOf('/'));
+        directory = url.substring(0, url.lastIndexOf('/'));
       }
       const myUrl = NSURL.URLWithString(encodeURI(url));
-      const myReadAccessUrl = NSURL.fileURLWithPath(url);
+      const myReadAccessUrl = NSURL.fileURLWithPath(directory);
       this._ios.loadFileURLAllowingReadAccessToURL(myUrl, myReadAccessUrl);
     } else {
       const reTilda = new RegExp('^~/');

--- a/src/webkit-webview.ios.ts
+++ b/src/webkit-webview.ios.ts
@@ -212,6 +212,7 @@ export class TNSWKWebView extends View {
   public static openEvent = 'open';
 
   public src: string;
+  public readAccessUrl: string;
   private _ios: WKWebView;
   private _messageHandlers: Array<string> = [];
   private _scriptMessageHandler: WKScriptMessageHandlerImpl;
@@ -292,7 +293,7 @@ export class TNSWKWebView extends View {
       src.startsWith('/') ||
       src.startsWith('file:///')
     ) {
-      this._loadUrl(src);
+      this._loadUrl(src, this.readAccessUrl);
     } else {
       this._loadData(src);
     }
@@ -357,12 +358,8 @@ export class TNSWKWebView extends View {
         : myUrl;
       this._ios.loadFileURLAllowingReadAccessToURL(myUrl, myReadAccessUrl);
     } else if (url.startsWith('file:///')) {
-      let directory = url;
-      if (url.indexOf('/') !== -1) {
-        directory = url.substring(0, url.lastIndexOf('/'));
-      }
       const myUrl = NSURL.URLWithString(encodeURI(url));
-      const myReadAccessUrl = NSURL.fileURLWithPath(directory);
+      const myReadAccessUrl = NSURL.fileURLWithPath(this.readAccessUrl || url);
       this._ios.loadFileURLAllowingReadAccessToURL(myUrl, myReadAccessUrl);
     } else {
       const reTilda = new RegExp('^~/');


### PR DESCRIPTION
Scenario (iOS):

Loading an offline directory of web assets into the WKWebView currently does not work with the plugin.

Example File Directory:
```
/html-site
   /index.html
   /images
        /foo.png
        /header.png
   /style.css
```

The device file access is different/more strict than the file-system on the Mac with the simulator. In order to satisfy the requirements of reading the related sub-files for the `index.html`, we need to alter the url to the root directory and pass it to `loadFileURLAllowingReadAccessToURL` so read access is applied to all the files.

I've only applied this fix for serving local content using the `file://` path. Also fixed the `NSURL.URLWithString` method as we were re-applying `file://` to the URL again. 